### PR TITLE
fix: remove LDL boolean classes

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -91,8 +91,8 @@ described above.
 For LDL, you can use the following classes,
 defined in `pylogics.syntax.ldl`:
 
-- `LDLTrue`, the boolean positive constant `tt`
-- `LDLFalse`, the boolean negative constant `ff`
+- `TrueFormula(logic=Logic.LDL)`, the boolean positive constant `tt`
+- `FalseFormula(logic=Logic.LDL)`, the boolean negative constant `ff`
 - `Diamond(regex, ldlf_formula)`
 - `Box(regex, ldlf_formula)`
 

--- a/pylogics/parsers/ldl.py
+++ b/pylogics/parsers/ldl.py
@@ -31,23 +31,12 @@ from pylogics.syntax.base import (
     FalseFormula,
     Formula,
     Implies,
+    Logic,
     Not,
     Or,
     TrueFormula,
 )
-from pylogics.syntax.ldl import (
-    Box,
-    Diamond,
-    End,
-    Last,
-    LDLFalse,
-    LDLTrue,
-    Prop,
-    Seq,
-    Star,
-    Test,
-    Union,
-)
+from pylogics.syntax.ldl import Box, Diamond, End, Last, Prop, Seq, Star, Test, Union
 from pylogics.syntax.pl import Atomic
 
 
@@ -123,11 +112,11 @@ class _LDLTransformer(AbstractTransformer):
 
     @classmethod
     def ldlf_tt(cls, args):
-        return LDLTrue()
+        return TrueFormula(logic=Logic.LDL)
 
     @classmethod
     def ldlf_ff(cls, args):
-        return LDLFalse()
+        return FalseFormula(logic=Logic.LDL)
 
     @classmethod
     def ldlf_last(cls, args):
@@ -139,18 +128,18 @@ class _LDLTransformer(AbstractTransformer):
 
     @classmethod
     def ldlf_prop_true(cls, args):
-        return Diamond(Prop(TrueFormula()), LDLTrue())
+        return Diamond(Prop(TrueFormula()), TrueFormula(logic=Logic.LDL))
 
     @classmethod
     def ldlf_prop_false(cls, args):
-        return Diamond(Prop(FalseFormula()), LDLTrue())
+        return Diamond(Prop(FalseFormula()), TrueFormula(logic=Logic.LDL))
 
     @classmethod
     def ldlf_prop_atom(cls, args):
         assert len(args) == 1
         token = args[0]
         symbol = str(token)
-        return Diamond(Prop(Atomic(symbol)), LDLTrue())
+        return Diamond(Prop(Atomic(symbol)), TrueFormula(logic=Logic.LDL))
 
     @classmethod
     def regular_expression(cls, args):

--- a/pylogics/syntax/ldl.py
+++ b/pylogics/syntax/ldl.py
@@ -59,38 +59,6 @@ class _RegularExpression(Formula):
         return Logic.RE
 
 
-class LDLTrue(TrueFormula):
-    """True formula of LDL."""
-
-    def __init__(self):
-        """Initialize."""
-        super().__init__(Logic.LDL)
-
-    def __repr__(self) -> str:
-        """Get an unambiguous string representation."""
-        return f"LDLTrue({self.logic})"
-
-    def __invert__(self) -> Formula:
-        """Negate."""
-        return LDLFalse()
-
-
-class LDLFalse(FalseFormula):
-    """False formula of LDL."""
-
-    def __init__(self):
-        """Initialize."""
-        super().__init__(Logic.LDL)
-
-    def __repr__(self) -> str:
-        """Get an unambiguous string representation."""
-        return f"LDLFalse({self.logic})"
-
-    def __invert__(self) -> Formula:
-        """Negate."""
-        return LDLTrue()
-
-
 class Seq(_BinaryOp, _RegularExpression):
     """Sequence of regular expressions."""
 
@@ -185,5 +153,5 @@ class Box(_TemporalFormula):
     """Box formula."""
 
 
-End = partial(Box, Prop(TrueFormula()), LDLFalse())
+End = partial(Box, Prop(TrueFormula()), FalseFormula(logic=Logic.LDL))
 Last = partial(Diamond, Prop(TrueFormula()), End())

--- a/pylogics/utils/to_string.py
+++ b/pylogics/utils/to_string.py
@@ -37,17 +37,7 @@ from pylogics.syntax.base import (
     Or,
     TrueFormula,
 )
-from pylogics.syntax.ldl import (
-    Box,
-    Diamond,
-    LDLFalse,
-    LDLTrue,
-    Prop,
-    Seq,
-    Star,
-    Test,
-    Union,
-)
+from pylogics.syntax.ldl import Box, Diamond, Prop, Seq, Star, Test, Union
 from pylogics.syntax.ltl import Always, Eventually, Next
 from pylogics.syntax.ltl import PropositionalFalse as LTLPropositionalFalse
 from pylogics.syntax.ltl import PropositionalTrue as LTLPropositionalTrue
@@ -211,18 +201,6 @@ def to_string_pltl_once(formula: Once) -> str:
 def to_string_pltl_historically(formula: Historically) -> str:
     """Transform a 'historically' formula into string."""
     return f"H({to_string(formula.argument)})"
-
-
-@to_string.register(LDLTrue)
-def to_string_ldl_true(_formula: LDLTrue) -> str:
-    """Transform an LDL true into string."""
-    return "tt"
-
-
-@to_string.register(LDLFalse)
-def to_string_ldl_false(_formula: LDLFalse) -> str:
-    """Transform an LDL false into string."""
-    return "ff"
 
 
 @to_string.register(Diamond)


### PR DESCRIPTION
## Proposed changes

Remove LDL boolean classes

Since we delegate string conversion to utility functions, the presence of 'LDLTrue' and 'LDLFalse' is useless.


## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a