### PR TITLE
Bugfix in LDLf test parser

### DIFF
--- a/pylogics/parsers/ldl.py
+++ b/pylogics/parsers/ldl.py
@@ -168,7 +168,7 @@ class _LDLTransformer(AbstractTransformer):
         if len(args) == 1:
             return args[0]
         if len(args) == 2:
-            _, formula = args
+            formula, _ = args
             return Test(formula)
         cls._raise_parsing_error(cls.re_test.__name__, args)
 

--- a/pylogics/syntax/base.py
+++ b/pylogics/syntax/base.py
@@ -167,6 +167,11 @@ class _BinaryOp(Formula):
             len(operands) >= 2,
             f"expected at least 2 operands, found {len(operands)} operands",
         )
+        enforce(
+            all(map(lambda x: isinstance(x, Formula), operands)),
+            "some argument is not an instance of 'Formula'",
+            exception_cls=ValueError,
+        )
         self._operands = list(operands)
 
     @property
@@ -227,6 +232,11 @@ class _UnaryOp(Formula, ABC):
 
         :param arg: the argument.
         """
+        enforce(
+            isinstance(arg, Formula),
+            "argument is not an instance of 'Formula'",
+            exception_cls=ValueError,
+        )
         super().__init__()
         self._arg = arg
 


### PR DESCRIPTION
## Proposed changes

The parser object for the LDLf Test operator was read incorrectly. We were reading the token ? instead of the associated formula.
Waning: I debugged through logaut. I didn't execute this repo directly.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
